### PR TITLE
Add start script and Next.js dependencies

### DIFF
--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, NextRequest } from 'next/server';
-import { sbAdmin } from '@/lib/supabase-admin';
-import { tgSend, formatOrder, kbForNew } from '@/lib/telegram';
+import { sbAdmin } from '../../../lib/supabase-admin';
+import { tgSend, formatOrder, kbForNew } from '../../../lib/telegram';
 
 export const runtime = 'nodejs';
 

--- a/app/api/tg/webhook/route.ts
+++ b/app/api/tg/webhook/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { sbAdmin } from '@/lib/supabase-admin';
-import { tgAnswerCb, tgEditText, formatOrder, kbTaken, tgSend, kbDM, kbRequestPhone } from '@/lib/telegram';
+import { sbAdmin } from '../../../../lib/supabase-admin';
+import { tgAnswerCb, tgEditText, formatOrder, kbTaken, tgSend, kbDM, kbRequestPhone } from '../../../../lib/telegram';
 
 export const runtime = 'nodejs';
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,19 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
     "test": "echo 'No tests'"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.39.5"
+    "@supabase/supabase-js": "^2.39.5",
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.13",
+    "typescript": "^5.9.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,39 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "noEmit": true,
+    "incremental": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add Next.js start/build scripts and required dependencies
- fix module resolution paths and imports for API routes

## Testing
- `npm test`
- `TG_BOT_TOKEN=1 NEXT_PUBLIC_SUPABASE_URL=https://example.com SUPABASE_SERVICE_ROLE_KEY=key npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c623348f34832db0147316eafacbc1