### PR TITLE
fix: lazily init Supabase client

### DIFF
--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse, NextRequest } from 'next/server';
-import { sbAdmin } from '../../../lib/supabase-admin';
+import { getAdminClient } from '../../../lib/supabase-admin';
 import { tgSend, formatOrder, kbForNew } from '../../../lib/telegram';
 
 export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   try {
+    const sbAdmin = getAdminClient();
     const body = await req.json().catch(() => ({}));
 
     // Ожидаем минимальный набор

--- a/app/api/tg/webhook/route.ts
+++ b/app/api/tg/webhook/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { sbAdmin } from '../../../../lib/supabase-admin';
+import { getAdminClient } from '../../../../lib/supabase-admin';
 import { tgAnswerCb, tgEditText, formatOrder, kbTaken, tgSend, kbDM, kbRequestPhone } from '../../../../lib/telegram';
 
 export const runtime = 'nodejs';
@@ -14,6 +14,7 @@ export async function POST(req: NextRequest) {
   const update = await req.json().catch(() => ({}));
 
   try {
+    const sbAdmin = getAdminClient();
     // 1) /bind_drivers_channel — отправляется ИЗ самого канала
     if (update.message?.text?.startsWith?.('/bind_drivers_channel')) {
       const chat = update.message.chat;

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,9 +1,18 @@
 import 'server-only';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const key = process.env.SUPABASE_SERVICE_ROLE_KEY!; // server-only
+let client: SupabaseClient | null = null;
 
-export const sbAdmin = createClient(url, key, {
-  auth: { persistSession: false, autoRefreshToken: false },
-});
+export function getAdminClient(): SupabaseClient {
+  if (!client) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY; // server-only
+    if (!url || !key) {
+      throw new Error('Supabase credentials are not set');
+    }
+    client = createClient(url, key, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+  return client;
+}


### PR DESCRIPTION
## Summary
- lazily create Supabase admin client with env var checks
- load Supabase client inside API route handlers

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6287aefe8832d9a60fcc0b597071e